### PR TITLE
docling dependencies differ based on version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,5 @@ fastapi-cors
 whisper
 num2words
 lxml[html_clean]
-num2words
-docling
+docling>=2.5.2
 langdetect


### PR DESCRIPTION
Specify docling version to eliminate build issues since pip saw that docling dependencies conflict depending on the version of docling