### PR TITLE
Fix article markdown rendering

### DIFF
--- a/frontend/components/BottomBar.tsx
+++ b/frontend/components/BottomBar.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import MarkdownRenderer from '@/components/MarkdownRenderer';
 
 interface Article {
   id: string;
@@ -97,19 +98,11 @@ export default function BottomBar({ articleId, type, audioFile }: BottomBarProps
           </div>
         </div>
 
-        <div className="flex gap-4 items-start h-[calc(100%-4rem)] overflow-hidden">
-          <div className="w-full overflow-y-auto pr-4">
-            {showTldr && article.tldr ? (
-              <div className="prose dark:prose-invert max-w-none">
-                {article.tldr}
-              </div>
-            ) : (
-              <div className="prose dark:prose-invert max-w-none">
-                {article.content}
-              </div>
-            )}
+          <div className="flex gap-4 items-start h-[calc(100%-4rem)] overflow-hidden">
+            <div className="w-full overflow-y-auto pr-4">
+              <MarkdownRenderer content={showTldr && article.tldr ? article.tldr : (article.content || '')} />
+            </div>
           </div>
-        </div>
 
         <div className="absolute bottom-4 left-4">
         </div>

--- a/frontend/components/MarkdownRenderer.tsx
+++ b/frontend/components/MarkdownRenderer.tsx
@@ -6,7 +6,7 @@ interface MarkdownRendererProps {
 
 export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
   return (
-    <div className="prose max-w-none">
+    <div className="prose dark:prose-invert max-w-none">
       <ReactMarkdown>{content}</ReactMarkdown>
     </div>
   );

--- a/main.py
+++ b/main.py
@@ -598,7 +598,7 @@ async def get_article_from_db(article_id: str):
             "title": article.get("title"),
             "date": article.get("date_published") or article.get("date_added"),
             "audio_file": audio_file,
-            "content": article.get("plain_text"),
+            "content": article.get("markdown_text") or article.get("plain_text"),
             "tl_dr": article.get("tl_dr"),
         }
         return JSONResponse(content=content)


### PR DESCRIPTION
## Summary
- send `markdown_text` if present from article endpoint
- render markdown in frontend bottom bar
- allow dark mode in MarkdownRenderer

## Testing
- `npm run lint` *(fails: `next` not found)*